### PR TITLE
Fixed tsc errors

### DIFF
--- a/Tools/Gulp/package.json
+++ b/Tools/Gulp/package.json
@@ -10,7 +10,7 @@
     "gulp": "^3.8.11",
     "gulp-uglify": "~1.5.3",
     "gulp-sourcemaps": "~1.9.1",
-    "typescript": "^2.1.4",
+    "typescript": "~2.1.4",
     "gulp-typescript": "^3.1.3",
     "through2": "~0.6.5",
     "gulp-util": "~3.0.4",

--- a/src/Tools/babylon.tools.ts
+++ b/src/Tools/babylon.tools.ts
@@ -908,8 +908,6 @@
             return "[" + padStr(date.getHours()) + ":" + padStr(date.getMinutes()) + ":" + padStr(date.getSeconds()) + "]: " + message;
         }
 
-        public static Log: (message: string) => void = Tools._LogEnabled;
-
         private static _LogDisabled(message: string): void {
             // nothing to do
         }
@@ -921,7 +919,7 @@
             Tools._AddLogEntry(entry);
         }
 
-        public static Warn: (message: string) => void = Tools._WarnEnabled;
+        public static Log: (message: string) => void = Tools._LogEnabled;
 
         private static _WarnDisabled(message: string): void {
             // nothing to do
@@ -934,7 +932,7 @@
             Tools._AddLogEntry(entry);
         }
 
-        public static Error: (message: string) => void = Tools._ErrorEnabled;
+        public static Warn: (message: string) => void = Tools._WarnEnabled;
 
         private static _ErrorDisabled(message: string): void {
             // nothing to do
@@ -947,6 +945,8 @@
             var entry = "<div style='color:red'>" + formattedMessage + "</div><br>";
             Tools._AddLogEntry(entry);
         }
+
+        public static Error: (message: string) => void = Tools._ErrorEnabled;
 
         public static get LogCache(): string {
             return Tools._LogCache;

--- a/src/babylon.mixins.ts
+++ b/src/babylon.mixins.ts
@@ -51,7 +51,7 @@ interface WebGLRenderingContext {
     texImage3D(target: number, level: number, internalformat: number, width: number, height: number, depth: number, border: number, format: number, type: number, pixels?: ArrayBufferView): void;
 }
 
-interface AudioContext extends EventTarget {
+interface AudioContextBase extends EventTarget {
     decodeAudioData(audioData: ArrayBuffer, successCallback: DecodeSuccessCallback, errorCallback?: any): void;
 }
 
@@ -84,6 +84,7 @@ interface CanvasRenderingContext2D {
     mozImageSmoothingEnabled: boolean;
     oImageSmoothingEnabled: boolean;
     webkitImageSmoothingEnabled: boolean;
+    msImageSmoothingEnabled: boolean;
 }
 
 interface WebGLTexture {


### PR DESCRIPTION
* AudioContext no longer extends EventTarget, but AudioContextBase does
* static Log/Warn/Error functions were used before declared
* msImageSmoothing used, but not (anymore) part of interface